### PR TITLE
[WIP] PDF Media File Deduplication

### DIFF
--- a/2025/pdf-media-deduplication.php
+++ b/2025/pdf-media-deduplication.php
@@ -1,4 +1,19 @@
 <?php
+/**
+ * PDF Media Deduplication WP-CLI Command
+ *
+ * Usage:
+ *   wp pdf-media deduplicate [--dry-run] [--start-post-id=<id>]
+ *
+ * Examples:
+ *   wp pdf-media deduplicate --dry-run
+ *   wp pdf-media deduplicate --start-post-id=500
+ *   wp pdf-media deduplicate --dry-run --start-post-id=1000
+ *
+ * Place this file in your WordPress environment and run the above commands from the terminal.
+ */
+
+use WP_CLI;
 // File: pdf-media-deduplication.php
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/2025/pdf-media-deduplication.php
+++ b/2025/pdf-media-deduplication.php
@@ -35,6 +35,13 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
         private $dry_run = false;
 
         /**
+         * Minimum post ID to start processing from.
+         *
+         * @var int
+         */
+        private $start_post_id = 1;
+
+        /**
          * Deduplicate PDF media files in the WordPress media library.
          *
          * ## OPTIONS
@@ -42,31 +49,54 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
          * [--dry-run]
          * : Run the command in test mode without making changes.
          *
+         * [--start-post-id=<id>]
+         * : Minimum post ID to start processing from.
+         *
          * ## EXAMPLES
          *
-         *     wp pdf-media deduplicate --dry-run
+         *     wp pdf-media deduplicate --dry-run --start-post-id=500
          *
          * @when after_wp_load
          */
         public function deduplicate( $args, $assoc_args ) {
             $this->dry_run = isset( $assoc_args['dry-run'] );
+            $this->start_post_id = isset( $assoc_args['start-post-id'] ) ? intval( $assoc_args['start-post-id'] ) : 1;
+
             if ( $this->dry_run ) {
                 WP_CLI::log( 'Running in dry run mode. No changes will be made.' );
             } else {
                 WP_CLI::log( 'Running in live mode. Changes will be applied.' );
             }
-            // Your deduplication logic here, using $this->dry_run to control actions.
+
+            if ( $this->start_post_id > 1 ) {
+                WP_CLI::log( "Starting from post ID: {$this->start_post_id}" );
+            }
+
+            // Your deduplication logic here, using $this->dry_run and $this->start_post_id to control actions.
             WP_CLI::success( 'PDF media deduplication completed.' );
         }
 
         private function get_pdf_posts() {
-            $args = array(
-                'post_type'      => 'attachment',
-                'post_mime_type' => 'application/pdf',
-                'posts_per_page' => -1,
+            global $wpdb;
+
+            $results = $wpdb->get_results(
+                $wpdb->prepare(
+                    "
+                    SELECT * FROM {$wpdb->posts}
+                    WHERE post_type = %s
+                      AND post_mime_type = %s
+                      AND ID >= %d
+                    ORDER BY ID ASC
+                    LIMIT %d
+                    ",
+                    'attachment',
+                    'application/pdf',
+                    $this->start_post_id,
+                    $this->batch_size
+                )
             );
-            $query = new WP_Query( $args );
-            return $query->posts;
+
+            return $results;
         }
     }
 

--- a/2025/pdf-media-deduplication.php
+++ b/2025/pdf-media-deduplication.php
@@ -42,6 +42,13 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
         private $start_post_id = 1;
 
         /**
+         * Holds the last post ID returned in the batch.
+         *
+         * @var int|null
+         */
+        private $last_post_id = null;
+
+        /**
          * Deduplicate PDF media files in the WordPress media library.
          *
          * ## OPTIONS
@@ -85,7 +92,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
                     SELECT * FROM {$wpdb->posts}
                     WHERE post_type = %s
                       AND post_mime_type = %s
-                      AND ID >= %d
+                      AND ID > %d
                     ORDER BY ID ASC
                     LIMIT %d
                     ",
@@ -95,6 +102,12 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
                     $this->batch_size
                 )
             );
+
+            // Set the last_post_id property to the last post ID in the results, if any
+            if ( ! empty( $results ) ) {
+                $last_post = end( $results );
+                $this->last_post_id = $last_post->ID;
+            }
 
             return $results;
         }

--- a/2025/pdf-media-deduplication.php
+++ b/2025/pdf-media-deduplication.php
@@ -67,7 +67,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
          */
         public function deduplicate( $args, $assoc_args ) {
             $this->dry_run = isset( $assoc_args['dry-run'] );
-            $this->start_post_id = isset( $assoc_args['start-post-id'] ) ? intval( $assoc_args['start-post-id'] ) : 1;
 
             if ( $this->dry_run ) {
                 WP_CLI::log( 'Running in dry run mode. No changes will be made.' );
@@ -75,12 +74,29 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
                 WP_CLI::log( 'Running in live mode. Changes will be applied.' );
             }
 
-            if ( $this->start_post_id > 1 ) {
-                WP_CLI::log( "Starting from post ID: {$this->start_post_id}" );
-            }
+            $this->determine_start_post_id( $assoc_args );
 
             // Your deduplication logic here, using $this->dry_run and $this->start_post_id to control actions.
             WP_CLI::success( 'PDF media deduplication completed.' );
+        }
+
+        /**
+         * Determine the starting post ID from CLI args or saved option.
+         *
+         * @param array $assoc_args
+         */
+        private function determine_start_post_id( $assoc_args ) {
+            if ( isset( $assoc_args['start-post-id'] ) ) {
+                $this->start_post_id = intval( $assoc_args['start-post-id'] );
+                WP_CLI::log( "Resuming from saved post ID: {$this->start_post_id}" );
+                return; // If a start post ID is provided, it should always take precedence.
+            }
+
+            $saved_start_post_id = get_option( 'one-time-script-pdf-deduplication-start-post-id' );
+            if ( $saved_start_post_id ) {
+                $this->start_post_id = intval( $saved_start_post_id );
+                WP_CLI::log( "Resuming from saved post ID: {$this->start_post_id}" );
+            }
         }
 
         private function get_pdf_posts() {
@@ -110,6 +126,15 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
             }
 
             return $results;
+        }
+
+        /**
+         * Save the last processed post ID to the wp_options table.
+         */
+        private function save_last_post_id_to_options() {
+            if ( ! is_null( $this->last_post_id ) ) {
+                update_option( 'one-time-script-pdf-deduplication-start-post-id', $this->last_post_id );
+            }
         }
     }
 

--- a/2025/pdf-media-deduplication.php
+++ b/2025/pdf-media-deduplication.php
@@ -13,17 +13,34 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
         private $batch_size = 100;
 
         /**
+         * Whether to run in test mode (dry run).
+         *
+         * @var bool
+         */
+        private $dry_run = false;
+
+        /**
          * Deduplicate PDF media files in the WordPress media library.
+         *
+         * ## OPTIONS
+         *
+         * [--dry-run]
+         * : Run the command in test mode without making changes.
          *
          * ## EXAMPLES
          *
-         *     wp pdf-media deduplicate
+         *     wp pdf-media deduplicate --dry-run
          *
          * @when after_wp_load
          */
         public function deduplicate( $args, $assoc_args ) {
-            WP_CLI::log( 'Starting PDF media deduplication...' );
-            // Your deduplication logic here.
+            $this->dry_run = isset( $assoc_args['dry-run'] );
+            if ( $this->dry_run ) {
+                WP_CLI::log( 'Running in dry run mode. No changes will be made.' );
+            } else {
+                WP_CLI::log( 'Running in live mode. Changes will be applied.' );
+            }
+            // Your deduplication logic here, using $this->dry_run to control actions.
             WP_CLI::success( 'PDF media deduplication completed.' );
         }
 


### PR DESCRIPTION

## Goal: Create a script which can evaluate PDF media files in batches. The goal is to remove any duplicate PDF files.

Features: 
- [x] Dry run mode (don’t execute the delete action)
- [x] Batch count - Determine how many posts to evaluate at a time
- [x] Start post ID
- [ ] An array of unique post names
- [ ] An array of possible duplicate postIDs
- [ ] A count of duplicate posts
- [ ] Store unique post titles/filenames in the database
- [x] Store the start_post_id in case the script is run multiple times in a row
- [ ] List how many files are possible duplicates
- [ ] Confirm deleting a file
- [ ] Fuzzy match the file name
- [ ] Delete the post AND the media file
- [ ] Have a separate command to remove the options created by this script

The flow should go like this:

`wp deduplicate-pdf –dry-run –batch=100 –start_post_id=0`

The command should do this first:
- Fetch the number of PDF files in the batch size starting at the start postID
- Loop through each post
- Check to see if the post title/filename is stored within the unique post titles
- If it is not, add the post title/filename to the unique post titles in a “postID” => “title” key value pair
- If it is, then add the file name to the duplicate postIDs array in a nested array format:
```
“title” => [
	First_post => unique post ID,
	duplicate_posts=> [postID, postID, postID],
]
```

At the end, the command should summarize how many unique post titles were found and how many duplicate posts were found.

The next step would be to loop through all of the duplicate posts and allow the user to choose if they want to delete or save the post.

Lastly, it should save the array of unique post names and the last post ID. This way, if the script is run again for the next batch, it can compare files for unique posts which have already been found.
